### PR TITLE
Fix PowerShell command

### DIFF
--- a/EMDocs/Solutions/ems-aip-premium-govt-service-description.md
+++ b/EMDocs/Solutions/ems-aip-premium-govt-service-description.md
@@ -113,7 +113,7 @@ You can use the following PowerShell commands to help you determine whether your
  
     $request = [System.Net.HttpWebRequest]::Create("https://admin.aadrm.us/admin/admin.svc")
     $request.GetResponse()
-    $request.ServicePoint.Certificate.Issuer
+    $request.ServicePoint.Certificate
 
 The result should show that the issuing CA is from a Microsoft CA, for example: `CN=Microsoft Secure Server CA 2011, O=Microsoft Corporation, L=Redmond, S=Washington, C=US`. If you see an issuing CA name that is not from Microsoft, it is very likely that your secure client-to-service connection is being terminated and needs to be reconfigured on your firewall.
 


### PR DESCRIPTION
The "Issuer" nested property on that object does not make it obvious this is a Microsoft certificate since it is chained to a common DigiCert Issuing CA. Omitting the "Issuer" nested property returns both the "Issuer" and the "Subject" which more helpful.

```
PS C:\> $request.ServicePoint.Certificate.Issuer
CN=DigiCert SHA2 Secure Server CA, O=DigiCert Inc, C=US
```

```
PS C:\> $request.ServicePoint.Certificate

       Handle Issuer                                                  Subject
       ------ ------                                                  -------
2338365787840 CN=DigiCert SHA2 Secure Server CA, O=DigiCert Inc, C=US CN=ssl.aadrm.us, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
```