### PR TITLE
Edit to GCC High exclusions for Remote Help app

### DIFF
--- a/EMDocs/Solutions/ems-intune-govt-service-description.md
+++ b/EMDocs/Solutions/ems-intune-govt-service-description.md
@@ -33,7 +33,7 @@ The Intune GCC High and DoD offering is built on the Microsoft Azure Government 
   - Co-Management support is only available with Configuration Manager version 1906 or later. 
   - Windows Autopilot and Business Store features are not available to GCC High and DoD customers at this time, though planning is underway. 
   - Intune for GCC High does not support the Mobile Threat Defense connector for Android and iOS devices. 
-  - The [Remote help](/mem/intune/remote-actions/ app is not supported in GCC High environments.
+  - The [remote help](/mem/intune/remote-actions/remote-help/) app isn't supported in GCC High environments.
 
 ## Next steps
-To learn more about Intune and explore how to get started, see the [Microsoft Intune documentation](/mem/intune/remote-actions/remote-help).
+To learn more about Intune and explore how to get started, see the [Microsoft Intune documentation](/mem/intune/remote-actions/).

--- a/EMDocs/Solutions/ems-intune-govt-service-description.md
+++ b/EMDocs/Solutions/ems-intune-govt-service-description.md
@@ -33,6 +33,7 @@ The Intune GCC High and DoD offering is built on the Microsoft Azure Government 
   - Co-Management support is only available with Configuration Manager version 1906 or later. 
   - Windows Autopilot and Business Store features are not available to GCC High and DoD customers at this time, though planning is underway. 
   - Intune for GCC High does not support the Mobile Threat Defense connector for Android and iOS devices. 
+  - The [Remote help](/mem/intune/remote-actions/ app is not supported in GCC High environments.
 
 ## Next steps
-To learn more about Intune and explore how to get started, see the [Microsoft Intune documentation](/mem/intune/).
+To learn more about Intune and explore how to get started, see the [Microsoft Intune documentation](/mem/intune/remote-actions/remote-help).


### PR DESCRIPTION
Remote help app content publishes on 11/24/2021 by 11:00am pacific,  via work item https://msazure.visualstudio.com/Intune/_workitems/edit/9843480 and PR https://msazure.visualstudio.com/Intune/_workitems/edit/9843480.   The product group has asked for this exclusion of support for GCC high be added to this article.